### PR TITLE
add scribe support, a medium.com frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 nx-freestance-handler is a redirector from mainstream websites to their privacy-supporting mirrors for the [Nyxt browser](https://github.com/atlas-engineer/nyxt). The code was inspired by [this issue](https://github.com/atlas-engineer/nyxt/issues/930). 
 
-It is currently able to redirect from Youtube to [Invidious](https://github.com/iv-org/invidious), from Reddit to [Teddit](https://codeberg.org/teddit/teddit), from Instagram to [Bibliogram](https://sr.ht/~cadence/bibliogram/), and from Twitter to [Nitter](https://github.com/zedeus/nitter).
+It is currently able to redirect from Youtube to [Invidious](https://github.com/iv-org/invidious), from Reddit to [Teddit](https://codeberg.org/teddit/teddit), from Instagram to [Bibliogram](https://sr.ht/~cadence/bibliogram/), from Medium to [Scribe](https://git.sr.ht/~edwardloveall/scribe) and from Twitter to [Nitter](https://github.com/zedeus/nitter).
 
 ## Installation
 
@@ -34,7 +34,7 @@ Then, create `freestance.lisp` file in `~/.config/nyxt` with these contents:
 
 ```common-lisp
 ;; to add all handlers/redirectors (youtube to invidious, reddit to teddit,
-;; instagram to bibliogram, twitter to nitter)
+;; instagram to bibliogram, medium to scribe, twitter to nitter)
 (setq *my-request-resource-handlers*
       (nconc *my-request-resource-handlers*
              nx-freestance-handler:*freestance-handlers*))
@@ -44,13 +44,14 @@ Then, create `freestance.lisp` file in `~/.config/nyxt` with these contents:
 ;; (push #'nx-freestance-handler:nitter-handler *my-request-resource-handlers*)
 ;; (push #'nx-freestance-handler:bibliogram-handler *my-request-resource-handlers*)
 ;; (push #'nx-freestance-handler:teddit-handler *my-request-resource-handlers*)
+;; (push #'nx-freestance-handler:scribe-handler *my-request-resource-handlers*)
 
 ;; to set your preferred instance, either invoke SET-PREFERRED-[name of website]-INSTANCE
 ;; command in Nyxt (the effect lasts until you close Nyxt), or write something like this:
 ;; (setf nx-freestance-handler:*preferred-invidious-instance* "https://invidious.snopyta.org")
 ```
 
-By default, for Invidious this handler redirects to the healthiest (i.e, with best uptime) instance available. For Teddit it redirects to the official teddit.net instance, for Nitter - to nitter.net and for Bibliogram - to bibliogram.art.
+By default, for Invidious this handler redirects to the healthiest (i.e, with best uptime) instance available. For Teddit it redirects to the official teddit.net instance, for Scribe - to scribe.rip, for Nitter - to nitter.net and for Bibliogram - to bibliogram.art.
 
 FYI, right now direct links to posts on Instagram are not redirected, as Bibliogram [doesn't seem to support](https://todo.sr.ht/~cadence/bibliogram-issues/26) them (yet?).
 

--- a/nx-freestance-handler.asd
+++ b/nx-freestance-handler.asd
@@ -29,5 +29,6 @@
                (:file "invidious-handler")
                (:file "teddit-handler")
                (:file "bibliogram-handler")
+               (:file "scribe-handler")
                (:file "nitter-handler")
                (:file "freestance-handler")))

--- a/package.lisp
+++ b/package.lisp
@@ -25,9 +25,11 @@
   (:export :*preferred-invidious-instance*
            :*preferred-teddit-instance*
            :*preferred-bibliogram-instance*
+           :*preferred-scribe-instance*
            :*preferred-nitter-instance*
            :*freestance-handlers*
            :invidious-handler
            :teddit-handler
            :bibliogram-handler
+           :scribe-handler
            :nitter-handler))

--- a/scribe-handler.lisp
+++ b/scribe-handler.lisp
@@ -1,0 +1,45 @@
+;;;; freestance-handler, a redirector from mainstream websites to their
+;;;; privacy-supporting mirrors for the Nyxt browser
+
+;;;; This program is free software: you can redistribute it and/or modify
+;;;; it under the terms of the GNU General Public License as published by
+;;;; the Free Software Foundation, either version 3 of the License, or
+;;;; (at your option) any later version.
+
+;;;; This program is distributed in the hope that it will be useful,
+;;;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;;;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;;;; GNU General Public License for more details.
+
+;;;; You should have received a copy of the GNU General Public License
+;;;; along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+;;;; scribe-handler.lisp
+
+(in-package :nx-freestance-handler)
+
+(defvar *preferred-scribe-instance* nil)
+
+(defun scribe-handler (request-data)
+  (let ((url (url request-data)))
+    (setf (url request-data)
+          ;; I think this might be the problem line
+          (if (search "medium.com" (quri:uri-host url))
+              (progn
+                (setf (quri:uri-host url) (or *preferred-scribe-instance*
+					      "scribe.rip"))
+                (log:info "Switching to Scribe: ~s" (render-url url))
+                url)
+              url)))
+  request-data)
+
+(in-package :nyxt)
+
+(define-command set-preferred-scribe-instance ()
+  "Set the preferred Scribe instance."
+  (let ((instance (prompt-minibuffer
+                   :input-prompt "Input the URL of the instance"
+                   :suggestion-function (history-suggestion-filter
+                                      :prefix-urls (list (object-string
+                                                          (url (current-buffer))))))))
+    (setf nx-freestance-handler:*preferred-scribe-instance* instance)))


### PR DESCRIPTION
Scribe is an alternative frontend to medium.com, not only is it significantly more minimal (loads 250kb instead of 3mb), it also loads quicker and some may prefer the "Tufte CSS" design.