### PR TITLE
Update nx-freestance-handler to work with 3.* changes

### DIFF
--- a/bibliogram-handler.lisp
+++ b/bibliogram-handler.lisp
@@ -36,8 +36,10 @@
               url)))
   request-data)
 
+#+nyxt-2
 (in-package :nyxt)
 
+#+nyxt-2
 (define-command set-preferred-bibliogram-instance ()
   "Set the preferred Bibliogram instance."
   (let ((instance (prompt-minibuffer
@@ -45,4 +47,13 @@
                    :suggestion-function (history-suggestion-filter
                                       :prefix-urls (list (object-string
                                                           (url (current-buffer))))))))
+    (setf nx-freestance-handler:*preferred-bibliogram-instance* instance)))
+
+#+nyxt-3
+(define-command-global set-preferred-bibliogram-instance ()
+  "Set the preferred Bibliogram instance."
+  (let ((instance (prompt
+                   :prompt "Input the URL of the instance"
+                   :sources (list (make-instance 'prompter:raw-source)
+                                  (make-instance 'nyxt/history-mode:history-all-source)))))
     (setf nx-freestance-handler:*preferred-bibliogram-instance* instance)))

--- a/invidious-handler.lisp
+++ b/invidious-handler.lisp
@@ -85,11 +85,22 @@ Defaults to one day.")
               url)))
   request-data)
 
+#+nyxt-2
 (in-package :nyxt)
 
+#+nyxt-2
 (define-command set-preferred-invidious-instance ()
   "Set the preferred invidious instance."
   (let ((instance (prompt-minibuffer
                    :input-prompt "Choose an instance"
                    :suggestion-function (nx-freestance-handler::invidious-instance-suggestion-filter))))
+    (setf nx-freestance-handler:*preferred-invidious-instance* (nx-freestance-handler::object-string instance))))
+
+#+nyxt-3
+(define-command-global set-preferred-invidious-instance ()
+  "Set the preferred invidious instance."
+  (let ((instance (prompt
+                   :prompt "Input the URL of the instance"
+                   :sources (list (make-instance 'prompter:raw-source)
+                                  (make-instance 'nyxt/history-mode:history-all-source)))))
     (setf nx-freestance-handler:*preferred-invidious-instance* (nx-freestance-handler::object-string instance))))

--- a/nitter-handler.lisp
+++ b/nitter-handler.lisp
@@ -32,8 +32,10 @@
               url)))
   request-data)
 
+#+nyxt-2
 (in-package :nyxt)
 
+#+nyxt-2
 (define-command set-preferred-nitter-instance ()
   "Set the preferred Nitter instance."
   (let ((instance (prompt-minibuffer
@@ -41,4 +43,13 @@
                    :suggestion-function (history-suggestion-filter
                                       :prefix-urls (list (object-string
                                                           (url (current-buffer))))))))
+    (setf nx-freestance-handler:*preferred-nitter-instance* instance)))
+
+#+nyxt-3
+(define-command-global set-preferred-nitter-instance ()
+  "Set the preferred Nitter instance."
+  (let ((instance (prompt
+                   :prompt "Input the URL of the instance"
+                   :sources (list (make-instance 'prompter:raw-source)
+                                  (make-instance 'nyxt/history-mode:history-all-source)))))
     (setf nx-freestance-handler:*preferred-nitter-instance* instance)))

--- a/scribe-handler.lisp
+++ b/scribe-handler.lisp
@@ -33,8 +33,10 @@
               url)))
   request-data)
 
+#+nyxt-2
 (in-package :nyxt)
 
+#+nyxt-2
 (define-command set-preferred-scribe-instance ()
   "Set the preferred Scribe instance."
   (let ((instance (prompt-minibuffer
@@ -42,4 +44,13 @@
                    :suggestion-function (history-suggestion-filter
                                       :prefix-urls (list (object-string
                                                           (url (current-buffer))))))))
+    (setf nx-freestance-handler:*preferred-scribe-instance* instance)))
+
+#+nyxt-3
+(define-command set-preferred-scribe-instance ()
+  "Set the preferred Scribe instance."
+  (let ((instance (prompt
+                   :prompt "Input the URL of the instance"
+                   :sources (list (make-instance 'prompter:raw-source)
+                                  (make-instance 'nyxt/history-mode:history-all-source)))))
     (setf nx-freestance-handler:*preferred-scribe-instance* instance)))

--- a/teddit-handler.lisp
+++ b/teddit-handler.lisp
@@ -32,8 +32,10 @@
               url)))
   request-data)
 
+#+nyxt-2
 (in-package :nyxt)
 
+#+nyxt-2
 (define-command set-preferred-teddit-instance ()
   "Set the preferred Teddit instance."
   (let ((instance (prompt-minibuffer
@@ -41,4 +43,13 @@
                    :suggestion-function (history-suggestion-filter
                                       :prefix-urls (list (object-string
                                                           (url (current-buffer))))))))
+    (setf nx-freestance-handler:*preferred-teddit-instance* instance)))
+
+#+nyxt-3
+(define-command-global set-preferred-teddit-instance ()
+  "Set the preferred Teddit instance."
+  (let ((instance (prompt
+                   :prompt "Input the URL of the instance"
+                   :sources (list (make-instance 'prompter:raw-source)
+                                  (make-instance 'nyxt/history-mode:history-all-source)))))
     (setf nx-freestance-handler:*preferred-teddit-instance* instance)))


### PR DESCRIPTION
This adds some reader macros and a 3-series versions of the existing commands so that those work with the most recent Nyxt.

There are likely to be more changes to Nyxt in the coming month, so I might send another PR.

@kssytsrk, looking fine to you?